### PR TITLE
Всегда использовать нейтральную локаль для парсинга OSM файлов.

### DIFF
--- a/OSM2Visio/Code/DrawTools.cs
+++ b/OSM2Visio/Code/DrawTools.cs
@@ -74,17 +74,7 @@ namespace OSM2Visio.Code
         /// <returns></returns>
         static public Double pf_StrToDbl(String a_Str)
         {
-            try
-            {
-                return Convert.ToDouble(a_Str.Replace(".", ","));
-            }
-            catch (Exception err)
-            {
-                //MessageBox.Show(err.Message);
-                return Convert.ToDouble(a_Str.Replace(",", "."));
-                //throw;
-            }
-
+            return Convert.ToDouble(a_Str, System.Globalization.CultureInfo.InvariantCulture);
         }
 
         #region Работа с координатами


### PR DESCRIPTION
Замена точки на запятую работает только для русского. И вообще это хак  😄 
Поменял на System.Globalization.CultureInfo.InvariantCulture, она всегда точку парсит (OSM всегда точки экспортирует)